### PR TITLE
Improved error handling for set_auth_token method

### DIFF
--- a/rocketchat/calls/base.py
+++ b/rocketchat/calls/base.py
@@ -29,8 +29,11 @@ class RocketChatBase(object):
                                  data={'user': self.settings['username'],
                                        'password': self.settings['password']})
 
-        self.auth_token = response.json()['data']['authToken']
-        self.auth_user_id = response.json()['data']['userId']
+        try:
+            self.auth_token = response.json()['data']['authToken']
+            self.auth_user_id = response.json()['data']['userId']
+        except KeyError:
+            response.raise_for_status()
 
     def set_auth_headers(self):
         self.headers['X-Auth-Token'] = self.auth_token


### PR DESCRIPTION
Improved error handling in set_auth_token method.

Before, it would only throw a `KeyError: 'data'` exception when the server responded with an error status, such as when invalid credentials are entered.

Now it calls `response.raise_for_status()` which responds with a more detailed/accurate error message.

Should resolve #24 